### PR TITLE
feat: move magic code to triggers to fix sync

### DIFF
--- a/app/Console/Commands/CreateAndReadyCompetitors.php
+++ b/app/Console/Commands/CreateAndReadyCompetitors.php
@@ -100,8 +100,6 @@ class CreateAndReadyCompetitors extends Command
 
         $count = DB::table('tracks')->insertOrIgnore($tracks);
 
-        $round->updateStatus();
-
         if (is_null($userId)) {
             $userId = $competition->creator->id;
         }

--- a/app/Console/Commands/FillMissingGuessesForCompetition.php
+++ b/app/Console/Commands/FillMissingGuessesForCompetition.php
@@ -59,7 +59,5 @@ class FillMissingGuessesForCompetition extends Command
                 ]);
             }
         }
-
-        $round->updateStatus();
     }
 }

--- a/app/Http/Controllers/TrackController.php
+++ b/app/Http/Controllers/TrackController.php
@@ -20,8 +20,6 @@ class TrackController extends Controller {
         $validated = $request->validate($rules);
 
         $track->update($validated);
-        $track->round->updateStatus();
-
         return response()->json($track);
     }
 
@@ -52,7 +50,6 @@ class TrackController extends Controller {
 
         $track = Track::create($data);
 
-        $track->round->updateStatus();
         $track->guesses = [];
 
         return response()->json($track, 201);
@@ -64,8 +61,6 @@ class TrackController extends Controller {
 
         // TODO: make sure validation rules accept empty spotify url and add validation here
         $track->update(["ready" => $request->ready]);
-
-        $track->round->updateStatus();
 
         return response()->json($track);
     }

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -38,6 +38,10 @@ class Competition extends Model {
         return [];
     }
 
+    public function isDemo() {
+        return $this->id === config('demo_constants.demo_competition_id');
+    }
+
     public function creator() {
         return $this->belongsTo(User::class, 'created_by');
     }

--- a/database/migrations/2024_12_08_221621_guess_whose_trigger_on_track_update.php
+++ b/database/migrations/2024_12_08_221621_guess_whose_trigger_on_track_update.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach (['INSERT', 'UPDATE'] as $trigger) {
+            $this->createTrigger($trigger);
+        }
+    }
+
+    public function createTrigger($trigger) {
+        $lowerTrigger = strtolower($trigger);
+
+        DB::unprepared(<<<EO
+            CREATE TRIGGER round_to_guess_whose_when_tracks_submitted_$lowerTrigger
+            AFTER $trigger ON tracks
+            FOR EACH ROW
+            BEGIN
+                DECLARE count_not_ready INT;
+
+                IF NEW.ready = 1 AND (SELECT r.status FROM rounds r WHERE r.id = NEW.round_id) = 'pick_track' THEN
+
+                    SELECT COUNT(*) INTO count_not_ready
+                    FROM (
+                        SELECT ru.user_id
+                        FROM round_user ru
+                        LEFT JOIN tracks t ON t.round_id = ru.round_id
+                        AND t.user_id = ru.user_id
+                        AND t.ready = 1
+                        WHERE ru.round_id = NEW.round_id
+                        GROUP BY ru.user_id
+                        HAVING COUNT(t.id) = 0
+                    ) AS sub;
+
+                    if count_not_ready = 0 THEN
+                        UPDATE rounds
+                        SET status = 'guess_whose', currently_playing_track = 0
+                        WHERE id = NEW.round_id;
+                    END IF;
+
+                END IF;
+            END
+        EO);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared(<<<EO
+            DROP TRIGGER IF EXISTS round_to_guess_whose_when_tracks_submitted;
+        EO);
+    }
+};

--- a/database/migrations/2024_12_08_221622_finished_trigger_on_guess_update.php
+++ b/database/migrations/2024_12_08_221622_finished_trigger_on_guess_update.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach (['INSERT', 'UPDATE'] as $trigger) {
+            $this->createTrigger($trigger);
+        }
+    }
+
+    public function createTrigger($trigger) {
+        $lowerTrigger = strtolower($trigger);
+        DB::unprepared(<<<EO
+            CREATE TRIGGER round_to_finished_when_guesses_submitted_$lowerTrigger
+            AFTER $trigger ON guesses
+            FOR EACH ROW
+            BEGIN
+                DECLARE round_guess_id INT;
+                DECLARE count_not_ready INT;
+
+                IF NEW.ready = 1 THEN
+                    SELECT t.round_id INTO round_guess_id FROM tracks t WHERE t.id = NEW.track_id;
+
+                    IF (SELECT r.status FROM rounds r WHERE r.id = round_guess_id) = 'guess_whose' THEN
+
+                        SELECT COUNT(*) INTO count_not_ready
+                        FROM (
+                            SELECT ru.user_id
+                            FROM round_user ru
+                            JOIN tracks t ON t.round_id = ru.round_id
+                            LEFT JOIN guesses g ON g.user_id = ru.user_id AND g.track_id = t.id AND g.ready = 1
+                            WHERE ru.round_id = round_guess_id
+                            GROUP BY ru.user_id
+                            HAVING COUNT(g.user_id) < COUNT(t.id)
+                        ) AS sub;
+
+                        IF count_not_ready = 0 THEN
+                            UPDATE rounds
+                            SET status = 'finished', currently_playing_track = 0
+                            WHERE id = round_guess_id;
+                        END IF;
+                    END IF;
+                END IF;
+            END
+        EO);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared(<<<EO
+            DROP TRIGGER IF EXISTS round_to_guess_whose_when_tracks_submitted;
+        EO);
+    }
+};

--- a/database/migrations/2024_12_18_221623_demo_on_guess_whose.php
+++ b/database/migrations/2024_12_18_221623_demo_on_guess_whose.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::unprepared(<<<EO
+            CREATE TRIGGER demo_on_guess_whose
+            AFTER UPDATE ON rounds
+            FOR EACH ROW
+            BEGIN
+                IF NEW.status = 'guess_whose' AND OLD.status != 'guess_whose' AND (NEW.id = 1 OR NEW.id = 2) THEN
+                    INSERT INTO guesses (user_id, track_id, guessed_user_id, ready)
+                    SELECT ru.user_id, t.id, ru.user_id, 1
+                    FROM round_user ru
+                    JOIN tracks t ON t.round_id = ru.round_id AND t.user_id = 1
+                    WHERE ru.round_id = NEW.id AND ru.user_id != 1;
+                END IF;
+            END
+        EO);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared(<<<EO
+            DROP TRIGGER IF EXISTS round_to_guess_whose_when_tracks_submitted;
+        EO);
+    }
+};

--- a/database/migrations/2024_12_18_221623_demo_on_pick_track.php
+++ b/database/migrations/2024_12_18_221623_demo_on_pick_track.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::unprepared(<<<EO
+            CREATE TRIGGER demo_on_pick_track
+            BEFORE UPDATE ON rounds
+            FOR EACH ROW
+            BEGIN
+                IF NEW.status = 'pick_track' AND OLD.status != 'pick_track' AND (NEW.id = 1 OR NEW.id = 2) THEN
+                    DELETE FROM guesses g WHERE g.track_id IN (SELECT t.id FROM tracks t WHERE t.round_id = NEW.id AND t.user_id = 1);
+                    DELETE FROM guesses g WHERE g.user_id = 1 AND g.track_id IN (SELECT t.id FROM tracks t WHERE t.round_id = NEW.id);
+                    DELETE FROM tracks t WHERE t.round_id = NEW.id AND t.user_id = 1;
+                END IF;
+            END
+        EO);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared(<<<EO
+            DROP TRIGGER IF EXISTS round_to_guess_whose_when_tracks_submitted;
+        EO);
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,7 +20,6 @@ Route::prefix('v1')->group(function () {
     Route::post('competitions/{competition_id}/rounds', [RoundController::class, 'store']);
 
     Route::post('rounds/{round_id}/tracks', [TrackController::class, 'store']);
-    Route::put('rounds/{round_id}/status', [RoundController::class, 'updateRoundStatus']);
     Route::put('rounds/{round_id}/tracks', [TrackController::class, 'updateByRound']);
 
     Route::delete('rounds/{round_id}/users/{user_id}', [RoundController::class, 'leaveRound']);


### PR DESCRIPTION
This will remove the magic update round status code which needs to be applied everywhere. This synchronises everything with triggers. Even adjusting the database (if the triggers are correct) will update the round statusses correctly.